### PR TITLE
Change version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.0.0
+## v1.0.0
 
 ### New features:
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.aws.greengrass</groupId>
     <artifactId>telemetry-nucleus-emitter</artifactId>
     <name>greengrass-telemetry-nucleus-emitter</name>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_default.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_default.yaml
@@ -11,7 +11,7 @@ services:
       telemetryPublishIntervalMs: "60000"
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_mqttTopic.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_mqttTopic.yaml
@@ -11,7 +11,7 @@ services:
       telemetryPublishIntervalMs: "100"
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_pubSubPublish.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_pubSubPublish.yaml
@@ -11,7 +11,7 @@ services:
       telemetryPublishIntervalMs: "100"
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_telemetryPublishIntervalMs.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_telemetryPublishIntervalMs.yaml
@@ -11,7 +11,7 @@ services:
       telemetryPublishIntervalMs: "garbage"
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_threshold.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_invalid_threshold.yaml
@@ -11,7 +11,7 @@ services:
       telemetryPublishIntervalMs: "100"
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_mqtt.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_mqtt.yaml
@@ -11,7 +11,7 @@ services:
       telemetryPublishIntervalMs: "60000"
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_no_options.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_no_options.yaml
@@ -7,7 +7,7 @@ services:
   aws.greengrass.telemetry.NucleusEmitter:
     dependencies:
       - "aws.greengrass.Nucleus:SOFT"
-    version: "2.9.3"
+    version: "1.0.0"
   main:
     dependencies:
       - "aws.greengrass.telemetry.NucleusEmitter"


### PR DESCRIPTION
**Description of changes:**
* Change version to 1.0.0 throughout to prepare for release
* All new components we are adding that have no equivalent GGv1 feature, we begin at 1.0. All features that have an equivalent GGv1 feature, then we start at 2.0 to avoid complex version wording


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
