### PR TITLE
chore: update github CI actions 

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,21 +32,21 @@ jobs:
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U clean verify
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
       - name: Build with Maven (Windows)
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U clean verify
         shell: cmd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
       - name: Upload Failed Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Failed Test Report
           path: target/surefire-reports
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: Coverage Report ${{ matrix.os }}


### PR DESCRIPTION
**Issue #, if available**:
N/A

**Description of changes**:

Update GitHub Actions CI workflow (.github/workflows/maven.yml) with the following changes:

- Pin Windows runner from windows-latest to windows-2022 to fix unit test failures caused by an OSHI/JNA incompatibility with Windows Server 2025. The bundled OSHI library does not
recognize the new CPU topology relationship type (`RelationEfficiencyClass`, value 7) introduced in Windows Server 2025, causing `ExceptionInInitializerError` in `SystemMetricsEmitter` and
cascading all 14 unit tests in `NucleusEmitterTest`, `MqttPublisherTest`, and `PubSubPublisherTest` to fail.
- Upgrade actions/upload-artifact from v3 to v4 for both the "Upload Failed Test Report" and "Upload Coverage" steps, as v3 is deprecated.

**Why is this change necessary**:

The windows-latest GitHub Actions runner recently moved to Windows Server 2025, which introduced a new logical processor relationship type that the project's OSHI dependency (via JNA)
cannot handle. This broke all Windows CI builds. Pinning to windows-2022 restores a compatible environment. The upload-artifact upgrade addresses the v3 deprecation.

**How was this change tested:**

CI pipeline runs on both `ubuntu-latest` and `windows-2022` matrix configurations.

Any additional information or context required to review the change:

This is a workaround. A longer-term fix would be to upgrade the OSHI and JNA dependencies to versions that support Windows Server 2025's hybrid CPU topology, which would allow switching back to windows-latest when we support Greengrass on Windows 2025

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
