### PR TITLE
feat: wire EMF file output into NucleusEmitter publish flow

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/nucleus/emitter/NucleusEmitterIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/nucleus/emitter/NucleusEmitterIntegrationTest.java
@@ -8,6 +8,8 @@ package com.aws.greengrass.integrationtests.telemetry.nucleus.emitter;
 import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.builtin.services.pubsub.PublishEvent;
 import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
@@ -30,7 +32,10 @@ import org.slf4j.event.Level;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
@@ -69,6 +74,8 @@ import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUti
 import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.INVALID_THRESHOLD_NUCLEUS_EMITTER_KERNEL_CONFIG;
 import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.NO_CONFIG_OPTIONS_NUCLEUS_EMITTER_KERNEL_CONFIG;
 import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.OUTPUT_MODE_BOTH_NUCLEUS_EMITTER_KERNEL_CONFIG;
+import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.OUTPUT_MODE_EMF_NUCLEUS_EMITTER_KERNEL_CONFIG;
+import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.EMF_FILE_TEST_KERNEL_CONFIG;
 import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.REGEX_DEFAULT_TELEMETRY_PUBSUB_TOPIC;
 import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.TEST_MQTT_TOPIC;
 import static com.aws.greengrass.telemetry.nucleus.emitter.NucleusEmitterTestUtils.format;
@@ -100,6 +107,12 @@ class NucleusEmitterIntegrationTest extends BaseITCase {
     @AfterEach
     void teardown() {
         kernel.shutdown();
+        Path emfDir = Paths.get("/tmp/greengrass/telemetry");
+        if (Files.isDirectory(emfDir)) {
+            try (java.util.stream.Stream<Path> files = Files.list(emfDir)) {
+                files.forEach(f -> f.toFile().delete());
+            } catch (IOException ignored) { }
+        }
     }
 
     private void defaultInitialization() throws Exception {
@@ -623,6 +636,138 @@ class NucleusEmitterIntegrationTest extends BaseITCase {
             assertTrue(configLog.await(30, TimeUnit.SECONDS), "Config log detected.");
             assertTrue(pubsubLog.await(30, TimeUnit.SECONDS), "Pub/sub publish log detected.");
         }
+    }
+
+    @Test
+    void GIVEN_output_mode_both_WHEN_publish_fires_THEN_emf_file_created() throws Exception {
+        // Clear GG LogManager's cached "emf-metrics" logger to avoid JVM-global cache pollution
+        // from other tests that create EmfFileWriter with a different outputDirectory.
+        clearCachedEmfLogger();
+
+        startKernelWithConfig(Objects.requireNonNull(NucleusEmitterTestUtils.class.getResource(
+                EMF_FILE_TEST_KERNEL_CONFIG)).toString(), kernel, rootDir);
+
+        // Poll for EMF file creation (5s publish interval, 30s timeout)
+        Path emfDir = Paths.get("/tmp/greengrass/telemetry");
+        long deadline = System.currentTimeMillis() + 30000;
+        long emfCount = 0;
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.isDirectory(emfDir)) {
+                try (java.util.stream.Stream<Path> files = Files.list(emfDir)) {
+                    emfCount = files.count();
+                }
+                if (emfCount > 0) {
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+        assertTrue(emfCount > 0, "EMF file created in output directory.");
+    }
+
+    @Test
+    void GIVEN_output_mode_emf_WHEN_publish_fires_THEN_emf_file_written_and_pubsub_publishes() throws Exception {
+        clearCachedEmfLogger();
+
+        final CountDownLatch pubsubLog = new CountDownLatch(1);
+        try (AutoCloseable listener = TestUtils.createCloseableLogListener((m) -> {
+            String stdoutStr = m.getMessage();
+            if (stdoutStr == null || stdoutStr.length() == 0) {return;}
+            if (stdoutStr.contains(PUBSUB_PUBLISH_STARTING)) {
+                pubsubLog.countDown();
+            }
+        })) {
+            startKernelWithConfig(Objects.requireNonNull(NucleusEmitterTestUtils.class.getResource(
+                    OUTPUT_MODE_EMF_NUCLEUS_EMITTER_KERNEL_CONFIG)).toString(), kernel, rootDir);
+            assertTrue(pubsubLog.await(30, TimeUnit.SECONDS), "Pub/sub publish log detected.");
+
+            // Verify EMF file is created
+            Path emfDir = Paths.get("/tmp/greengrass/telemetry");
+            long deadline = System.currentTimeMillis() + 30000;
+            long emfCount = 0;
+            while (System.currentTimeMillis() < deadline) {
+                if (Files.isDirectory(emfDir)) {
+                    try (java.util.stream.Stream<Path> files = Files.list(emfDir)) {
+                        emfCount = files.count();
+                    }
+                    if (emfCount > 0) {
+                        break;
+                    }
+                }
+                Thread.sleep(1000);
+            }
+            assertTrue(emfCount > 0, "EMF file created in output directory with outputMode emf.");
+        }
+    }
+
+    @Test
+    void GIVEN_output_mode_both_WHEN_changed_to_ipc_THEN_config_applied() throws Exception {
+        clearCachedEmfLogger();
+
+        final CountDownLatch pubsubLog = new CountDownLatch(1);
+        try (AutoCloseable listener = TestUtils.createCloseableLogListener((m) -> {
+            String stdoutStr = m.getMessage();
+            if (stdoutStr == null || stdoutStr.length() == 0) {return;}
+            if (stdoutStr.contains(PUBSUB_PUBLISH_STARTING)) {
+                pubsubLog.countDown();
+            }
+        })) {
+            startKernelWithConfig(Objects.requireNonNull(NucleusEmitterTestUtils.class.getResource(
+                    EMF_FILE_TEST_KERNEL_CONFIG)).toString(), kernel, rootDir);
+            assertTrue(pubsubLog.await(30, TimeUnit.SECONDS), "Component started with EMF.");
+
+            // Switch to ipc mode
+            Topics configTopic = Objects.requireNonNull(
+                    kernel.findServiceTopic("aws.greengrass.telemetry.NucleusEmitter"))
+                    .findTopics("configuration");
+            configTopic.lookup("outputMode").withValue("ipc");
+
+            // Give handleConfiguration time to process
+            Thread.sleep(2000);
+
+            // Verify component is still RUNNING (didn't crash from config change)
+            assertEquals(State.RUNNING,
+                    kernel.locate("aws.greengrass.telemetry.NucleusEmitter").getState(),
+                    "Component still running after outputMode change to ipc.");
+        }
+    }
+
+    @Test
+    void GIVEN_default_ipc_config_WHEN_publish_fires_THEN_no_emf_files() throws Exception {
+        final CountDownLatch pubsubLog = new CountDownLatch(1);
+        try (AutoCloseable listener = TestUtils.createCloseableLogListener((m) -> {
+            String stdoutStr = m.getMessage();
+            if (stdoutStr == null || stdoutStr.length() == 0) {return;}
+            if (stdoutStr.contains(PUBSUB_PUBLISH_STARTING)) {
+                pubsubLog.countDown();
+            }
+        })) {
+            startKernelWithConfig(Objects.requireNonNull(NucleusEmitterTestUtils.class.getResource(
+                    DEFAULT_NUCLEUS_EMITTER_KERNEL_CONFIG)).toString(), kernel, rootDir);
+            assertTrue(pubsubLog.await(30, TimeUnit.SECONDS), "Pub/sub publish log detected.");
+
+            // Wait a couple publish cycles then verify no EMF files
+            Thread.sleep(5000);
+            Path emfDir = Paths.get("/tmp/greengrass/telemetry");
+            long emfCount = 0;
+            if (Files.isDirectory(emfDir)) {
+                try (java.util.stream.Stream<Path> files = Files.list(emfDir)) {
+                    emfCount = files.count();
+                }
+            }
+            assertEquals(0, emfCount, "No EMF files with default ipc outputMode.");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearCachedEmfLogger() throws Exception {
+        Field loggerMapField = LogManager.class.getDeclaredField("loggerMap");
+        loggerMapField.setAccessible(true);
+        ((java.util.concurrent.ConcurrentMap<String, ?>) loggerMapField.get(null)).remove("emf-metrics");
+
+        Field logConfigsField = LogManager.class.getDeclaredField("logConfigurations");
+        logConfigsField.setAccessible(true);
+        ((java.util.Map<String, ?>) logConfigsField.get(null)).remove("emf-metrics");
     }
 
     @Test

--- a/src/main/java/com/aws/greengrass/telemetry/nucleus/emitter/NucleusEmitter.java
+++ b/src/main/java/com/aws/greengrass/telemetry/nucleus/emitter/NucleusEmitter.java
@@ -9,12 +9,15 @@ import com.aws.greengrass.config.ChildChanged;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.telemetry.impl.Metric;
+import com.aws.greengrass.telemetry.nucleus.emitter.emf.EmfFileWriter;
 import com.aws.greengrass.telemetry.nucleus.emitter.metrics.KernelMetricsEmitter;
 import com.aws.greengrass.telemetry.nucleus.emitter.metrics.SystemMetricsEmitter;
 import com.aws.greengrass.telemetry.nucleus.emitter.publisher.MqttPublisher;
 import com.aws.greengrass.telemetry.nucleus.emitter.publisher.PubSubPublisher;
+import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.SerializerFactory;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -22,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -64,6 +68,8 @@ public class NucleusEmitter extends PluginService {
     //Metric publishers
     private final PubSubPublisher pubSubPublisher;
     private final MqttPublisher mqttPublisher;
+    // volatile ensures visibility across config subscriber and publish threads
+    private volatile EmfFileWriter emfFileWriter;
 
     private final ChildChanged subscribeToConfigChanges = (what, topic) ->
             handleConfiguration(this.config.lookupTopics(CONFIGURATION_CONFIG_KEY));
@@ -108,9 +114,14 @@ public class NucleusEmitter extends PluginService {
                 .equals(newConfiguration.getExcludeMounts());
         boolean excludeInterfacesChanged = !configuration.getExcludeInterfaces()
                 .equals(newConfiguration.getExcludeInterfaces());
+        boolean outputModeChanged = !configuration.getOutputMode()
+                .equals(newConfiguration.getOutputMode());
+        boolean outputDirectoryChanged = !configuration.getOutputDirectory()
+                .equals(newConfiguration.getOutputDirectory());
 
         if (!pubSubPublishChanged && !mqttTopicChanged && !telemetryPublishIntervalMsChanged
-                && !metricsLevelChanged && !excludeMountsChanged && !excludeInterfacesChanged) {
+                && !metricsLevelChanged && !excludeMountsChanged && !excludeInterfacesChanged
+                && !outputModeChanged && !outputDirectoryChanged) {
             return;
         }
 
@@ -138,6 +149,14 @@ public class NucleusEmitter extends PluginService {
                     newConfiguration.getExcludeMounts(),
                     newConfiguration.getExcludeInterfaces());
         }
+        if (outputModeChanged || outputDirectoryChanged) {
+            if (newConfiguration.isEmfEnabled()) {
+                this.emfFileWriter = new EmfFileWriter(getThingName(),
+                        Paths.get(newConfiguration.getOutputDirectory()));
+            } else {
+                this.emfFileWriter = null; // NOPMD NullAssignment - disables EMF output
+            }
+        }
         scheduleTelemetryPublish();
     }
 
@@ -151,14 +170,34 @@ public class NucleusEmitter extends PluginService {
         scheduleTelemetryPublish();
     }
 
-    private void publishTelemetry(boolean pubSubPublish, String pubSubTopic, boolean mqttPublish, String mqttTopic) {
-        String jsonString = retrieveMetricsJson(jsonMapper);
-        if (pubSubPublish) {
-            this.pubSubPublisher.publishMessage(jsonString, pubSubTopic);
+    private void publishTelemetry(boolean pubSubPublish, String pubSubTopic,
+                                  boolean mqttPublish, String mqttTopic) {
+        List<Metric> metrics = collectMetrics();
+        if (pubSubPublish || mqttPublish) {
+            String jsonString = null; // NOPMD - set in try, checked before use
+            try {
+                jsonString = jsonMapper.writeValueAsString(metrics);
+            } catch (JsonProcessingException e) {
+                logger.error(JSON_PARSE_ERROR_LOG, e);
+            }
+            if (pubSubPublish && jsonString != null) {
+                this.pubSubPublisher.publishMessage(jsonString, pubSubTopic);
+            }
+            if (mqttPublish && jsonString != null) {
+                this.mqttPublisher.publishMessage(jsonString, mqttTopic);
+            }
         }
-        if (mqttPublish) {
-            this.mqttPublisher.publishMessage(jsonString, mqttTopic);
+        EmfFileWriter localEmf = this.emfFileWriter;
+        if (localEmf != null) {
+            localEmf.write(metrics);
         }
+    }
+
+    private List<Metric> collectMetrics() {
+        SystemMetricsEmitter localSme = this.sme;
+        return Stream.of(localSme.getMetrics(), kme.getMetrics())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
     }
 
     private void scheduleTelemetryPublish() {
@@ -192,13 +231,9 @@ public class NucleusEmitter extends PluginService {
     }
 
     protected String retrieveMetricsJson(ObjectMapper jsonMapper) {
-
         String jsonString = null;
         try {
-            SystemMetricsEmitter localSme = this.sme;
-            List<Metric> metrics = Stream.of(localSme.getMetrics(), kme.getMetrics())
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toList());
+            List<Metric> metrics = collectMetrics();
             jsonString = jsonMapper.writeValueAsString(metrics);
         } catch (JsonProcessingException e) {
             logger.error(JSON_PARSE_ERROR_LOG, e);
@@ -209,6 +244,13 @@ public class NucleusEmitter extends PluginService {
     @Override
     public void shutdown() {
         cancelJob(telemetryPublishFuture, telemetryPublishInProgressLock, true);
+        this.emfFileWriter = null; // NOPMD NullAssignment - release on shutdown
+    }
+
+    private String getThingName() {
+        return Coerce.toString(
+                this.context.get(DeviceConfiguration.class)
+                        .getThingName());
     }
 
     private void cancelJob(ScheduledFuture<?> future, Object lock, boolean immediately) {

--- a/src/main/java/com/aws/greengrass/telemetry/nucleus/emitter/metrics/SystemMetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/telemetry/nucleus/emitter/metrics/SystemMetricsEmitter.java
@@ -12,6 +12,8 @@
 
 package com.aws.greengrass.telemetry.nucleus.emitter.metrics;
 
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.telemetry.impl.Metric;
 import com.aws.greengrass.telemetry.models.TelemetryAggregation;
 import com.aws.greengrass.telemetry.models.TelemetryUnit;
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 public class SystemMetricsEmitter extends PeriodicMetricsEmitter {
+    private static final Logger logger = LogManager.getLogger(SystemMetricsEmitter.class);
     private static final int MB_CONVERTER = 1024 * 1024;
     private static final int PERCENTAGE_CONVERTER = 100;
     public static final String NAMESPACE = "SystemMetrics";
@@ -144,7 +147,8 @@ public class SystemMetricsEmitter extends PeriodicMetricsEmitter {
                     continue;
                 }
             } catch (SocketException e) {
-                // Interface unavailable (e.g. being removed); skip this cycle, next call retries
+                logger.atDebug().kv("interface", name)
+                        .cause(e).log("Skipping unavailable network interface");
                 continue;
             }
             if (excludeInterfaces.contains(name)) {

--- a/src/test/java/com/aws/greengrass/telemetry/nucleus/emitter/NucleusEmitterTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/nucleus/emitter/NucleusEmitterTest.java
@@ -6,8 +6,11 @@
 package com.aws.greengrass.telemetry.nucleus.emitter;
 
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.telemetry.impl.Metric;
+import com.aws.greengrass.telemetry.nucleus.emitter.emf.EmfFileWriter;
 import com.aws.greengrass.telemetry.nucleus.emitter.metrics.KernelMetricsEmitter;
 import com.aws.greengrass.telemetry.nucleus.emitter.metrics.SystemMetricsEmitter;
 import com.aws.greengrass.telemetry.nucleus.emitter.publisher.MqttPublisher;
@@ -82,6 +85,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class NucleusEmitterTest extends GGServiceTestUtil {
@@ -571,6 +575,140 @@ class NucleusEmitterTest extends GGServiceTestUtil {
         emitter.shutdown();
     }
 
+    @Test
+    void GIVEN_emf_writer_set_WHEN_publishTelemetry_THEN_writes_emf()
+            throws Exception {
+        initializeMockedConfig();
+        emitter = new NucleusEmitter(
+                this.config, mockKme, mockPubSubPublisher,
+                mockMqttPublisher, mockScheduledExecutorService);
+        setSmeField(emitter, mockSme);
+        when(mockSme.getMetrics())
+                .thenReturn(Collections.emptyList());
+        when(mockKme.getMetrics())
+                .thenReturn(Collections.emptyList());
+
+        EmfFileWriter mockEmf = mock(EmfFileWriter.class, // NOPMD - mock
+                withSettings().useConstructor("test", java.nio.file.Paths.get("/tmp")));
+        setEmfWriterField(emitter, mockEmf);
+
+        invokePublishTelemetry(emitter, false,
+                DEFAULT_TELEMETRY_PUBSUB_TOPIC, false, "");
+
+        verify(mockEmf).write(any());
+    }
+
+    @Test
+    void GIVEN_no_emf_writer_WHEN_publishTelemetry_THEN_skips_emf()
+            throws Exception {
+        initializeMockedConfig();
+        emitter = new NucleusEmitter(
+                this.config, mockKme, mockPubSubPublisher,
+                mockMqttPublisher, mockScheduledExecutorService);
+        setSmeField(emitter, mockSme);
+        when(mockSme.getMetrics())
+                .thenReturn(Collections.emptyList());
+        when(mockKme.getMetrics())
+                .thenReturn(Collections.emptyList());
+
+        invokePublishTelemetry(emitter, true,
+                DEFAULT_TELEMETRY_PUBSUB_TOPIC, false, "");
+
+        verify(mockPubSubPublisher).publishMessage(
+                any(), eq(DEFAULT_TELEMETRY_PUBSUB_TOPIC));
+    }
+
+    // EmfFileWriter no longer implements Closeable — GG logging framework manages files.
+
+    @Test
+    void GIVEN_outputMode_changed_WHEN_handleConfiguration_THEN_recreates_emf()
+            throws Exception {
+        initializeMockedConfig();
+        emitter = new NucleusEmitter(
+                this.config, mockKme, mockPubSubPublisher,
+                mockMqttPublisher, mockScheduledExecutorService);
+        setSmeField(emitter, mockSme);
+        setContextField(emitter);
+
+        Map<String, Object> pojo = new HashMap<>();
+        pojo.put("outputMode", "both");
+        pojo.put("outputDirectory", "/tmp/test-emf");
+
+        Topics configTopics = mock(Topics.class);
+        when(configTopics.toPOJO()).thenReturn(pojo);
+        stubSchedule();
+        invokeHandleConfiguration(emitter, configTopics);
+
+        assertNotNull(getEmfWriterField(emitter));
+        assertEquals("both",
+                emitter.getCurrentConfiguration().get()
+                        .getOutputMode());
+    }
+
+    @Test
+    void GIVEN_outputMode_ipc_WHEN_handleConfiguration_THEN_no_emf()
+            throws Exception {
+        initializeMockedConfig();
+        emitter = new NucleusEmitter(
+                this.config, mockKme, mockPubSubPublisher,
+                mockMqttPublisher, mockScheduledExecutorService);
+        setSmeField(emitter, mockSme);
+        setContextField(emitter);
+
+        // First set outputMode to "both" so EMF writer is created
+        Map<String, Object> bothPojo = new HashMap<>();
+        bothPojo.put("outputMode", "both");
+        bothPojo.put("outputDirectory", "/tmp/test-emf");
+        Topics bothTopics = mock(Topics.class);
+        when(bothTopics.toPOJO()).thenReturn(bothPojo);
+        stubSchedule();
+        invokeHandleConfiguration(emitter, bothTopics);
+        assertNotNull(getEmfWriterField(emitter));
+
+        // Now transition to "ipc" — EMF writer should be closed
+        Map<String, Object> ipcPojo = new HashMap<>();
+        ipcPojo.put("outputMode", "ipc");
+        ipcPojo.put("outputDirectory", "/tmp/test-emf");
+        Topics ipcTopics = mock(Topics.class);
+        when(ipcTopics.toPOJO()).thenReturn(ipcPojo);
+        invokeHandleConfiguration(emitter, ipcTopics);
+
+        assertNull(getEmfWriterField(emitter));
+    }
+
+    @Test
+    void GIVEN_outputDirectory_changed_WHEN_handleConfiguration_THEN_recreates_emf()
+            throws Exception {
+        initializeMockedConfig();
+        emitter = new NucleusEmitter(
+                this.config, mockKme, mockPubSubPublisher,
+                mockMqttPublisher, mockScheduledExecutorService);
+        setSmeField(emitter, mockSme);
+        setContextField(emitter);
+
+        // First set outputMode to "both"
+        Map<String, Object> pojo1 = new HashMap<>();
+        pojo1.put("outputMode", "both");
+        pojo1.put("outputDirectory", "/tmp/emf-a");
+        Topics topics1 = mock(Topics.class);
+        when(topics1.toPOJO()).thenReturn(pojo1);
+        stubSchedule();
+        invokeHandleConfiguration(emitter, topics1);
+        EmfFileWriter first = getEmfWriterField(emitter); // NOPMD - managed by NucleusEmitter
+        assertNotNull(first);
+
+        // Change only outputDirectory
+        Map<String, Object> pojo2 = new HashMap<>();
+        pojo2.put("outputMode", "both");
+        pojo2.put("outputDirectory", "/tmp/emf-b");
+        Topics topics2 = mock(Topics.class);
+        when(topics2.toPOJO()).thenReturn(pojo2);
+        invokeHandleConfiguration(emitter, topics2);
+        EmfFileWriter second = getEmfWriterField(emitter); // NOPMD - managed by NucleusEmitter
+        assertNotNull(second);
+        assertNotSame(first, second);
+    }
+
     // --- helpers ---
 
     private static void setSmeField(
@@ -594,6 +732,65 @@ class NucleusEmitterTest extends GGServiceTestUtil {
                 .getDeclaredField("telemetryPublishFuture");
         f.setAccessible(true);
         f.set(target, future);
+    }
+
+    private static void setEmfWriterField(
+            NucleusEmitter target, EmfFileWriter writer)
+            throws Exception {
+        Field f = NucleusEmitter.class
+                .getDeclaredField("emfFileWriter");
+        f.setAccessible(true);
+        f.set(target, writer);
+    }
+
+    private static EmfFileWriter getEmfWriterField(
+            NucleusEmitter target) throws Exception {
+        Field f = NucleusEmitter.class
+                .getDeclaredField("emfFileWriter");
+        f.setAccessible(true);
+        return (EmfFileWriter) f.get(target);
+    }
+
+    private static void setContextField(NucleusEmitter target)
+            throws Exception {
+        Context mockContext = mock(Context.class); // NOPMD - mock
+        DeviceConfiguration mockDeviceConfig =
+                mock(DeviceConfiguration.class);
+        com.aws.greengrass.config.Topic mockTopic =
+                mock(com.aws.greengrass.config.Topic.class);
+        when(mockTopic.getOnce()).thenReturn("test-thing");
+        when(mockDeviceConfig.getThingName())
+                .thenReturn(mockTopic);
+        when(mockContext.get(DeviceConfiguration.class))
+                .thenReturn(mockDeviceConfig);
+        Field f = target.getClass().getField("context");
+        f.setAccessible(true);
+        f.set(target, mockContext);
+    }
+
+    @Test
+    void GIVEN_emf_only_WHEN_publishTelemetry_THEN_no_json_serialization()
+            throws Exception {
+        initializeMockedConfig();
+        emitter = new NucleusEmitter(
+                this.config, mockKme, mockPubSubPublisher,
+                mockMqttPublisher, mockScheduledExecutorService);
+        setSmeField(emitter, mockSme);
+        when(mockSme.getMetrics())
+                .thenReturn(Collections.emptyList());
+        when(mockKme.getMetrics())
+                .thenReturn(Collections.emptyList());
+
+        EmfFileWriter mockEmf = mock(EmfFileWriter.class, // NOPMD - mock
+                withSettings().useConstructor("test", java.nio.file.Paths.get("/tmp")));
+        setEmfWriterField(emitter, mockEmf);
+
+        invokePublishTelemetry(emitter, false,
+                DEFAULT_TELEMETRY_PUBSUB_TOPIC, false, "");
+
+        verify(mockPubSubPublisher, never()).publishMessage(any(), any());
+        verify(mockMqttPublisher, never()).publishMessage(any(), any());
+        verify(mockEmf).write(any());
     }
 
     private void stubSchedule() {

--- a/src/test/java/com/aws/greengrass/telemetry/nucleus/emitter/NucleusEmitterTestUtils.java
+++ b/src/test/java/com/aws/greengrass/telemetry/nucleus/emitter/NucleusEmitterTestUtils.java
@@ -52,6 +52,9 @@ public final class NucleusEmitterTestUtils {
             "config_detailed_with_mqtt.yaml";
     public static final String OUTPUT_MODE_BOTH_NUCLEUS_EMITTER_KERNEL_CONFIG =
             "config_output_mode_both.yaml";
+    public static final String EMF_FILE_TEST_KERNEL_CONFIG = "config_emf.yaml";
+    public static final String OUTPUT_MODE_EMF_NUCLEUS_EMITTER_KERNEL_CONFIG =
+            "config_output_mode_emf.yaml";
 
 
     public static String readJsonFromFile(String filename) throws IOException, URISyntaxException {

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_emf.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_emf.yaml
@@ -1,0 +1,20 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.telemetry.NucleusEmitter:
+    configuration:
+      pubSubPublish: "true"
+      mqttTopic: ""
+      telemetryPublishIntervalMs: "5000"
+      outputMode: "both"
+      outputDirectory: "/tmp/greengrass/telemetry"
+    dependencies:
+      - "aws.greengrass.Nucleus:SOFT"
+    version: "1.0.0"
+  main:
+    dependencies:
+      - "aws.greengrass.telemetry.NucleusEmitter"
+    lifecycle: {}

--- a/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_output_mode_emf.yaml
+++ b/src/test/resources/com/aws/greengrass/telemetry/nucleus/emitter/config_output_mode_emf.yaml
@@ -1,0 +1,20 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.telemetry.NucleusEmitter:
+    configuration:
+      pubSubPublish: "true"
+      mqttTopic: ""
+      telemetryPublishIntervalMs: "5000"
+      outputMode: "emf"
+      outputDirectory: "/tmp/greengrass/telemetry"
+    dependencies:
+      - "aws.greengrass.Nucleus:SOFT"
+    version: "1.0.0"
+  main:
+    dependencies:
+      - "aws.greengrass.telemetry.NucleusEmitter"
+    lifecycle: {}


### PR DESCRIPTION
**Issue #, if available:**

N/A — PR 4 of 4 in the extended metrics stacked series.

**Description of changes:**

Wire EMF file output into `NucleusEmitter` publish flow and update documentation:
- Add `DeviceConfiguration` to constructor for `thingName`
- Create/close `EmfFileWriter` in `handleConfiguration()` when `outputMode` or `outputDirectory` changes
- Write metrics to `EmfFileWriter` in `publishTelemetry()` when `isEmfEnabled()`
- Close `EmfFileWriter` on shutdown
- README updated with all new config fields and extended metrics documentation

🤖 Assisted by AI

**Why is this change necessary:**

Completes the end-to-end flow: config (PR 1) → collect metrics (PR 2) → EMF writer (PR 3) → wire into publish loop (this PR). The emitter can now simultaneously publish via IPC/MQTT and write EMF files.

**How was this change tested:**

- Unit tests for EMF wiring (emf-only, both, ipc-only modes)
- `config_emf.yaml` test configuration
- Deployed on EC2 with `outputMode: both` — PubSub and EMF files working simultaneously

**Any additional information or context required to review the change:**

Depends on PR #21. Final PR in the stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.